### PR TITLE
chore(certora): dont wait for results

### DIFF
--- a/certora/confs/XPToken.conf
+++ b/certora/confs/XPToken.conf
@@ -3,7 +3,6 @@
   "msg": "Verifying XPToken.sol",
   "rule_sanity": "basic",
   "verify": "XPToken:certora/specs/XPToken.spec",
-  "wait_for_results": "all",
   "optimistic_loop": true,
   "loop_iter": "3",
   "packages": [


### PR DESCRIPTION
This is so the verify command doesn't block.

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [x] Ran `pnpm verify`?
