### PR TITLE
chore(RewardsStreamerMP): add `Initializable` to inheritance

### DIFF
--- a/src/RewardsStreamerMP.sol
+++ b/src/RewardsStreamerMP.sol
@@ -9,7 +9,13 @@ import { IStakeManager } from "./interfaces/IStakeManager.sol";
 import { TrustedCodehashAccess } from "./TrustedCodehashAccess.sol";
 
 // Rewards Streamer with Multiplier Points
-contract RewardsStreamerMP is UUPSUpgradeable, IStakeManager, TrustedCodehashAccess, ReentrancyGuardUpgradeable {
+contract RewardsStreamerMP is
+    Initializable,
+    UUPSUpgradeable,
+    IStakeManager,
+    TrustedCodehashAccess,
+    ReentrancyGuardUpgradeable
+{
     error StakingManager__AmountCannotBeZero();
     error StakingManager__TransferFailed();
     error StakingManager__InsufficientBalance();


### PR DESCRIPTION
Looks like we've forgotten about this. `Initializable` is imported but not applied on the contract.

## Description

Describe the changes made in your pull request here.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [x] Ran `pnpm adorno`?
- [x] Ran `pnpm verify`?
