### PR TITLE
test: make max MP test stronger

### DIFF
--- a/test/RewardsStreamerMP.t.sol
+++ b/test/RewardsStreamerMP.t.sol
@@ -790,7 +790,8 @@ contract StakeTest is RewardsStreamerMPTest {
 
         // move forward in time to check we're not producing more MP
         currentTime = vm.getBlockTimestamp();
-        vm.warp(currentTime + 1);
+        // increasing time by some big enough time such that MPs are actually generated
+        vm.warp(currentTime + 14 days);
 
         streamer.updateGlobalState();
         streamer.updateAccountMP(vaults[alice]);


### PR DESCRIPTION
As mentioned in #82, increasing `currentTime` by 1 second isn't enough to actually create new MPs, so the test could return false positives.

This change increases the time between checks arbritraryly longer, such that MPs would actually be created if the max MP wasn't reached.

Closes #82


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [x] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
