### PR TITLE
refactor(RewardsStreamerMP): move `totalMpStaked` to avoid collision

### DIFF
--- a/src/RewardsStreamerMP.sol
+++ b/src/RewardsStreamerMP.sol
@@ -44,7 +44,6 @@ contract RewardsStreamerMP is
     uint256 public constant SCALE_FACTOR = 1e18;
 
     uint256 public totalStaked;
-    uint256 public totalMPStaked;
     uint256 public totalMPAccrued;
     uint256 public totalMaxMP;
     uint256 public rewardIndex;
@@ -71,6 +70,8 @@ contract RewardsStreamerMP is
     mapping(address vault => VaultData data) public vaultData;
     mapping(address owner => address[] vault) public vaults;
     mapping(address vault => address owner) public vaultOwners;
+
+    uint256 public totalMPStaked;
 
     modifier onlyRegisteredVault() {
         if (vaultOwners[msg.sender] == address(0)) {


### PR DESCRIPTION
This field was added in between existing fields, causing a storage collision and corruption of existing data.

Storage layout before #123 

```
╭----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------╮
| Name                 | Type                                                 | Slot | Offset | Bytes | Contract                                    |
+===================================================================================================================================================+
| trustedCodehashes    | mapping(bytes32 => bool)                             | 0    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| STAKING_TOKEN        | contract IERC20                                      | 1    | 0      | 20    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalStaked          | uint256                                              | 2    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMPAccrued       | uint256                                              | 3    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMaxMP           | uint256                                              | 4    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardIndex          | uint256                                              | 5    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastMPUpdatedTime    | uint256                                              | 6    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| emergencyModeEnabled | bool                                                 | 7    | 0      | 1     | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalRewardsAccrued  | uint256                                              | 8    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardAmount         | uint256                                              | 9    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastRewardTime       | uint256                                              | 10   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardStartTime      | uint256                                              | 11   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardEndTime        | uint256                                              | 12   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| accounts             | mapping(address => struct RewardsStreamerMP.Account) | 13   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaults               | mapping(address => address[])                        | 14   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaultOwners          | mapping(address => address)                          | 15   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
╰----------------------+------------------------------------------------------+------+--------+-------+---------------------------------------------╯
```

Storage layout after #123 

```
╭----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------╮
| Name                 | Type                                                   | Slot | Offset | Bytes | Contract                                    |
+=====================================================================================================================================================+
| trustedCodehashes    | mapping(bytes32 => bool)                               | 0    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| STAKING_TOKEN        | contract IERC20                                        | 1    | 0      | 20    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalStaked          | uint256                                                | 2    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMPStaked        | uint256                                                | 3    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMPAccrued       | uint256                                                | 4    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMaxMP           | uint256                                                | 5    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardIndex          | uint256                                                | 6    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastMPUpdatedTime    | uint256                                                | 7    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| emergencyModeEnabled | bool                                                   | 8    | 0      | 1     | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalRewardsAccrued  | uint256                                                | 9    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardAmount         | uint256                                                | 10   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastRewardTime       | uint256                                                | 11   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardStartTime      | uint256                                                | 12   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardEndTime        | uint256                                                | 13   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaultData            | mapping(address => struct RewardsStreamerMP.VaultData) | 14   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaults               | mapping(address => address[])                          | 15   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaultOwners          | mapping(address => address)                            | 16   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
╰----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------╯
```

Notice how `totalMpStaked` bleeds into `totalMpAccrued`.

Storage layout with **this** change:

```
╭----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------╮
| Name                 | Type                                                   | Slot | Offset | Bytes | Contract                                    |
+=====================================================================================================================================================+
| trustedCodehashes    | mapping(bytes32 => bool)                               | 0    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| STAKING_TOKEN        | contract IERC20                                        | 1    | 0      | 20    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalStaked          | uint256                                                | 2    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMPAccrued       | uint256                                                | 3    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMaxMP           | uint256                                                | 4    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardIndex          | uint256                                                | 5    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastMPUpdatedTime    | uint256                                                | 6    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| emergencyModeEnabled | bool                                                   | 7    | 0      | 1     | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalRewardsAccrued  | uint256                                                | 8    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardAmount         | uint256                                                | 9    | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| lastRewardTime       | uint256                                                | 10   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardStartTime      | uint256                                                | 11   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| rewardEndTime        | uint256                                                | 12   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaultData            | mapping(address => struct RewardsStreamerMP.VaultData) | 13   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaults               | mapping(address => address[])                          | 14   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| vaultOwners          | mapping(address => address)                            | 15   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
|----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------|
| totalMPStaked        | uint256                                                | 16   | 0      | 32    | src/RewardsStreamerMP.sol:RewardsStreamerMP |
╰----------------------+--------------------------------------------------------+------+--------+-------+---------------------------------------------╯
```

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [x] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
