### PR TITLE
ci: add `--via-ir` option to coverage task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         uses: "foundry-rs/foundry-toolchain@v1"
 
       - name: "Generate the coverage report using the unit and the integration tests"
-        run: 'forge coverage --match-path "test/**/*.sol" --report lcov'
+        run: 'forge coverage --match-path "test/**/*.sol" --ir-minimum --report lcov'
 
       - name: "Upload coverage report to Codecov"
         uses: "codecov/codecov-action@v3"


### PR DESCRIPTION
This is to avoid stack too deep errors when testing

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
