### PR TITLE
specs(EmergencyMode): add complementary rule for emergency mode

### DIFF
--- a/certora/specs/EmergencyMode.spec
+++ b/certora/specs/EmergencyMode.spec
@@ -24,6 +24,18 @@ definition isUUPSUpgradeableFunction(method f) returns bool = (
   f.selector == sig:streamer.__TrustedCodehashAccess_init(address).selector
 );
 
+definition noCallDuringEmergency(method f) returns bool = (
+  f.selector == sig:streamer.updateGlobalState().selector
+                || f.selector == sig:streamer.registerVault().selector
+                || f.selector == sig:streamer.migrateToVault(address).selector
+                || f.selector == sig:streamer.compound(address).selector
+                || f.selector == sig:streamer.updateVaultMP(address).selector
+                || f.selector == sig:streamer.unstake(uint256).selector
+                || f.selector == sig:streamer.stake(uint256, uint256).selector
+                || f.selector == sig:streamer.lock(uint256).selector
+                || f.selector == sig:enableEmergencyMode().selector
+);
+
 rule accountCanOnlyLeaveInEmergencyMode(method f) {
   env e;
   calldataarg args;
@@ -40,4 +52,20 @@ rule accountCanOnlyLeaveInEmergencyMode(method f) {
                         isInitializerFunction(f) ||
                         isUUPSUpgradeableFunction(f);
 }
+
+rule cantBeCalledInEmergency(method f) 
+{
+    env e;
+    calldataarg args;
+
+    bool inEmergencyMode = emergencyModeEnabled();
+    
+    f@withrevert(e, args);
+    bool isReverted = lastReverted;
+
+    assert inEmergencyMode && noCallDuringEmergency(f) => isReverted;
+
+    satisfy !noCallDuringEmergency(f) => !isReverted && inEmergencyMode;
+}
+
 


### PR DESCRIPTION
This rule checks explicitly which functions should not be callable when emegency mode is enabled.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [x] Ran `pnpm verify`?
