### PR TITLE
test(certora): ensure Karma owneable functions are callable only by the owner

### DIFF
--- a/certora/specs/Karma.spec
+++ b/certora/specs/Karma.spec
@@ -1,18 +1,26 @@
 using Karma as karma;
 
+methods {
+    function owner() external returns (address) envfree;
+}
+
 // TODO:
 // totalDistributorAllocation can only increase
 // totalDistributorAllocation == sum of all distributor allocations
 // sum of external supply <= total supply
-// addRewardDistributor only owner
-// removeRewardDistributor only owner
-// setReward only owner
-// mint only owner
 
 definition isERC20TransferFunction(method f) returns bool = (
   f.selector == sig:karma.transfer(address, uint256).selector
                 || f.selector == sig:karma.transferFrom(address, address, uint256).selector
                 || f.selector == sig:karma.approve(address, uint256).selector
+);
+
+definition isOwnableFunction(method f) returns bool = (
+  f.selector == sig:karma.addRewardDistributor(address).selector
+                || f.selector == sig:karma.removeRewardDistributor(address).selector
+                || f.selector == sig:karma.setReward(address, uint256, uint256).selector
+                || f.selector == sig:karma.mint(address, uint256).selector
+
 );
 
 rule erc20TransferIsDisabled(method f) {
@@ -23,4 +31,16 @@ rule erc20TransferIsDisabled(method f) {
     bool isReverted = lastReverted;
 
     assert isERC20TransferFunction(f) => isReverted;
+}
+
+rule ownableFuncsOnlyCallableByOwner(method f) {
+    env e;
+    calldataarg args;
+
+    bool isOwner = owner() == e.msg.sender;
+
+    f@withrevert(e, args);
+    bool isReverted = lastReverted;
+
+    assert isOwnableFunction(f) && !isOwner => isReverted;
 }


### PR DESCRIPTION
## Description

Certora: ensure Karma owneable functions are callable only by the owner

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [x] Ran `pnpm verify`?
