### PR TITLE
refactor(TrustedCodehashAccess): rename storage gap variable

### DIFF
--- a/src/TrustedCodehashAccess.sol
+++ b/src/TrustedCodehashAccess.sol
@@ -15,7 +15,8 @@ abstract contract TrustedCodehashAccess is ITrustedCodehashAccess, OwnableUpgrad
     /// @notice Whidelisted codehashes.
     mapping(bytes32 codehash => bool permission) private trustedCodehashes;
     /// @notice Gap for upgrade safety.
-    uint256[10] private __gap;
+    // solhint-disable-next-line
+    uint256[10] private __gap_TrustedcodehashAccess;
 
     /**
      * @notice Restricts access based on the codehash of the caller.


### PR DESCRIPTION
When debugging storage layouts, it's actually hard to follow where all the `__gap` fields are coming from when multiple upgradeable contracts are part of the dependency chain.

This commit changes the name of `__gap` toa contract specific name, allowing for clarity when inspecting storage layouts.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [x] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
